### PR TITLE
Switch bladeRF sample format to SC16 Q11

### DIFF
--- a/src/bladeRF_source.cc
+++ b/src/bladeRF_source.cc
@@ -208,7 +208,7 @@ int bladeRF_source::open(unsigned int subdev) {
 
 		status = bladerf_sync_config(bdev,
 				BLADERF_MODULE_RX,
-				BLADERF_FORMAT_SC16_Q12,
+				BLADERF_FORMAT_SC16_Q11,
 				DEFAULT_STREAM_BUFFERS,
 				DEFAULT_STREAM_SAMPLES,
 				DEFAULT_STREAM_XFERS,


### PR DESCRIPTION
The SC16 Q12 macro name was a misnomer that was marked deprecated and
replaced with a more appropriately named SC16 Q11 macro in 01/2014. The
deprecated SC16 Q12 macro was removed from libbladeRF in 10/1024.
