### PR TITLE
README.md: Suggest cal backup and use of bladeRF-cli

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,6 +2,60 @@
 
 The bladeRF has an on-board VCTCXO (Voltage Controlled Temperature Compensated Crystal Oscillator) that is factory calibrated to within 20ppb. This calibration is partly found by reading the VCTCXO's output frequency with a frequency counter as the on-board trim DAC's output voltage is modified programmatically. The goal of the calibration procedure is to get the VCTCXO's output frequency to be as close to 38.4MHz as possible. Unfortunately due to the fact that components age, the factory calibration does not remain valid for more than a year at a time. To counteract the effects of component aging, kalibrate-bladeRF can be used to find a new DAC trim voltage to bring the VCTCXO's output frequency back to 38.4MHz. In the factory a 10ppb OCXO frequency counter is used to detect the error, kalibrate-bladeRF instead requires nothing more than a bladeRF and a GSM antenna. kalibrate-bladeRF works by listening to special GSM channels (timeslots) known as FCCHs (Frequency Correction Channel) to determine its frequency offset from the basestation.
 
+## Important Information ##
+
+## Back Up Existing Calibration Data ###
+It is ***very*** important that you first back up the factory-calibrated VCTCXO
+trim value prior to attempting to change it. This [bladeRF wiki
+page](https://github.com/Nuand/bladeRF/wiki/bladeRF-CLI-Tips-and-Tricks#Backing_up_and_restoring_calibration_data)
+describes how to do this. At a minimum, write down and keep the ''VCTCXO DAC
+calibration'' value reported by the bladeRF-cli:
+```
+$ bladeRF-cli -i
+bladeRF> info
+
+  Serial #:                 xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx
+  VCTCXO DAC calibration:   0x8a41  <---------------- [Save this value]
+  FPGA size:                40 KLE
+  FPGA loaded:              yes
+  USB bus:                  12
+  USB address:              2
+  USB speed:                SuperSpeed
+  Backend:                  libusb
+  Instance:                 0
+
+```
+
+## Temporarily Testing New Calibration Values ##
+Note that the `bladeRF-cli` program allows you to temporarily and immediately
+apply a VCTCXO trim value, using the `set trimdac <value>` command. 
+
+Before writing a new value to flash, it is ***highly*** recommend that you
+first test out any new values using the aforementioned `bladeRF-cli` command.
+When using the `set trimdac <value>` command, this trim value will be used by
+the hardware until this command issued again with a different value, or the
+device is reset.
+
+For example, if a calibration value of 0x932b is desired:
+
+```
+$ bladeRF-cli -i
+bladeRF> set trimdac 0x932b
+bladeRF> quit
+```
+
+or alternatively...
+
+```
+bladeRF-cli -e 'set trimdac 0x932b'
+```
+
+Note that the bladeRF-cli `info` command will still show the value in flash, rather than the temporarily applied value.
+
+Once content with this value, the wiki page linked earlier can be followed to write this value to flash, if desired.
+
+### Channel Selection ###
+This implementation currently does not include digital filtering (issue #4).  Until this is addressed, one needs to identify a channel that does not have any strong neighboring signals within the hardware's minimum 1.5 MHz LPF bandwidth setting, and specify the use of that channel.
 
 
 ## Compiling ##
@@ -46,7 +100,7 @@ Begin calibrating by specifying an ARFCN with argument -c. Based on the previous
 ./kal -c 128
 </pre>
 
-Alternatively argument `-w` can be specified to have kalibrate-bladeRF automatically update the on-board calibration table.
+Alternatively argument `-w` can be specified to have kalibrate-bladeRF automatically update the on-board calibration table. ***It is not recommended that you use this argument, unless you have backed up your previous calibration value!***
 
 <pre>
 ./kal -c 128 -w


### PR DESCRIPTION
Until some of the issues I have filed are resolved, it would be best to suggest that
users do not write cal values to flash. The README.md has been updated
accordingly. It suggests using the bladeRF-cli to test out trim values first.