### PR TITLE
Add win32 support (also fixes OS X compile error)

### DIFF
--- a/src/arfcn_freq.cc
+++ b/src/arfcn_freq.cc
@@ -27,7 +27,9 @@
 
 #include <stdio.h>
 #include <stdlib.h>
+#ifndef _WIN32
 #include <unistd.h>
+#endif
 #include <string.h>
 #include "arfcn_freq.h"
 

--- a/src/c0_detect.cc
+++ b/src/c0_detect.cc
@@ -39,6 +39,10 @@ extern int g_verbosity;
 
 static const float ERROR_DETECT_OFFSET_MAX = 40e3;
 
+#ifdef _WIN32
+#define BUFSIZ 1024
+#endif
+
 static double vectornorm2(const complex *v, const unsigned int len) {
 
 	unsigned int i;
@@ -53,8 +57,8 @@ static double vectornorm2(const complex *v, const unsigned int len) {
 
 int c0_detect(bladeRF_source *u, int bi, int mult) {
 
-	static const double GSM_RATE = 1625000.0 / 6.0;
-	static const unsigned int NOTFOUND_MAX = 10;
+#define GSM_RATE (1625000.0 / 6.0)
+#define  NOTFOUND_MAX 10
 
 	int i, chan_count;
 	unsigned int overruns, b_len, frames_len, found_count, notfound_count, r;

--- a/src/circular_buffer.h
+++ b/src/circular_buffer.h
@@ -45,6 +45,9 @@
  */
 
 #include <pthread.h>
+#ifdef _WIN32
+#include <Windows.h>
+#endif
 
 class circular_buffer {
 public:
@@ -66,6 +69,11 @@ public:
 	unsigned int buf_len();
 
 private:
+#ifdef _WIN32
+	HANDLE d_handle;
+	LPVOID d_first_copy;
+	LPVOID d_second_copy;
+#endif
 	void *m_buf;
 	unsigned int m_buf_len, m_buf_size, m_r, m_w, m_item_size;
 	unsigned long long m_read, m_written;

--- a/src/fcch_detector.h
+++ b/src/fcch_detector.h
@@ -65,8 +65,8 @@ public:
 	unsigned int x_purge(unsigned int);
 
 private:
-	static const double GSM_RATE = 1625000.0 / 6.0;
-	static const unsigned int FFT_SIZE = 1024;
+#define GSM_RATE (1625000.0 / 6.0)
+#define FFT_SIZE 1024
 
 	unsigned int	m_w_len,
 			m_D,

--- a/src/kal.cc
+++ b/src/kal.cc
@@ -44,12 +44,15 @@
 
 #include <stdio.h>
 #include <stdlib.h>
+#ifndef _WIN32
 #include <unistd.h>
+#include <sys/time.h>
+#endif
 #ifdef D_HOST_OSX
 #include <libgen.h>
 #endif /* D_HOST_OSX */
 #include <string.h>
-#include <sys/time.h>
+
 #include <errno.h>
 
 #include "bladeRF_source.h"
@@ -58,8 +61,13 @@
 #include "offset.h"
 #include "c0_detect.h"
 #include "version.h"
+#ifdef _WIN32
+#include <getopt.h>
+#define basename(x) "meh"
+#define strtof strtod
+#endif
 
-static const double GSM_RATE = 1625000.0 / 6.0;
+#define GSM_RATE (1625000.0 / 6.0)
 
 
 int g_verbosity = 0;

--- a/src/offset.cc
+++ b/src/offset.cc
@@ -29,6 +29,9 @@
 #include "fcch_detector.h"
 #include "util.h"
 
+#ifdef _WIN32
+inline double round(double x) { return floor(x + 0.5); }
+#endif
 
 static const unsigned int	AVG_COUNT	= 100;
 static const unsigned int	AVG_THRESHOLD	= (AVG_COUNT / 10);
@@ -39,7 +42,7 @@ extern int g_verbosity;
 
 int offset_detect(bladeRF_source *u, float *off) {
 
-	static const double GSM_RATE = 1625000.0 / 6.0;
+#define GSM_RATE (1625000.0 / 6.0)
 
 	unsigned int new_overruns = 0, overruns = 0;
 	int notfound = 0;

--- a/src/util.cc
+++ b/src/util.cc
@@ -27,6 +27,7 @@
 
 #include <stdio.h>
 #include <stdlib.h>
+#define _USE_MATH_DEFINES
 #include <math.h>
 
 


### PR DESCRIPTION
Merges this commit from @Hoernchen: https://github.com/scateu/kalibrate-hackrf/commit/482dd05ecdc79f5bacba898d8339baffbcddbc36 add win32 support Signed-off-by: Steve Markgraf steve@steve-m.de

This claims to add Windows support, haven't tested it myself but it fixed https://github.com/Nuand/kalibrate-bladeRF/issues/7 Compile error on Mac OS X:

```
cch_detector.cc:318:17: error: expression is not assignable
                fft[i].real() = m_out[i][0];
                ~~~~~~~~~~~~~ ^
fcch_detector.cc:319:17: error: expression is not assignable
                fft[i].imag() = m_out[i][1];
                ~~~~~~~~~~~~~ ^
```
